### PR TITLE
feat: Add WrapSilent() to wrap an error but not include it in the JSON body

### DIFF
--- a/problem.go
+++ b/problem.go
@@ -194,6 +194,15 @@ func Wrap(err error) Option {
 	})
 }
 
+// WrapSilent wraps an error inside of the Problem without placing the wrapped
+// error into the problem's JSON body.  Useful for cases where the underlying
+// error needs to be preserved but not transmitted to the user.
+func WrapSilent(err error) Option {
+	return optionFunc(func(problem *Problem) {
+		problem.reason = err
+	})
+}
+
 // Type sets the type URI (typically, with the "http" or "https" scheme) that identifies the problem type.
 // When dereferenced, it SHOULD provide human-readable documentation for the problem type
 func Type(uri string) Option {

--- a/problem_test.go
+++ b/problem_test.go
@@ -253,6 +253,16 @@ func TestNestedErrors(t *testing.T) {
 	if errors.Unwrap(unwrappedProblem) != nil {
 		t.Fatalf("Expected unwrappedProblem has no reason")
 	}
+	// See wrapped error in 'reason'
+	if p.JSONString() != `{"reason":"{\"status\":404,\"title\":\"Root Problem\"}","title":"high level error msg"}` {
+		t.Fatalf("Unexpected contents %s in problem", p.JSONString())
+	}
+
+	p = problem.New(problem.WrapSilent(rootProblem), problem.Title("high level error msg"))
+	// We should not see a "reason" here
+	if p.JSONString() != `{"title":"high level error msg"}` {
+		t.Fatalf("Unexpected contents %s in problem", p.JSONString())
+	}
 }
 
 func TestOsErrorInProblem(t *testing.T) {


### PR DESCRIPTION
In trying to use this project together with the echo web server, I ran into a lot of trouble with logging.  At least for me, in the server log, you want to have both the ProblemDetail and the underlying error.  But I don't want to send that error out to the end user, because (a) it's full of jargon and (b) it could have implementation details that I am not interesting in disclosing to the end user.

While it's possible to invent error middle-layers (and I have) to fix this issue, maybe a better was is to be able to `Wrap()` another error without it appearing in the body of the ProblemDetails JSON.  I don't love the name `WrapSilent()` but that's what I came up with.  I'm happy to change it (or, feel free) if you think of something you like better.  Thanks!